### PR TITLE
deleted extended scrolling at the bottom for all pages

### DIFF
--- a/src/components/user-management.jsx
+++ b/src/components/user-management.jsx
@@ -577,7 +577,7 @@ function UserManagement() {
                 Create Pipeline
               </Button>
             </DialogTrigger>
-            <DialogContent className="sm:max-w-[600px] bg-white max-h-[90vh] overflow-y-auto">
+            <DialogContent className="sm:max-w-[600px] bg-white max-h-[85vh] overflow-y-auto">
               <DialogHeader>
                 <DialogTitle className="text-gray-900 text-center">
                   {currentStep === 1

--- a/src/index.css
+++ b/src/index.css
@@ -2,6 +2,109 @@
 @tailwind components;
 @tailwind utilities;
 
+/* Fix scrolling issue - prevent extra space */
+html, body, #root {
+  height: 100vh;
+  overflow: hidden;
+}
+
+#root {
+  display: flex;
+  flex-direction: column;
+}
+
+/* Dashboard layout height constraints */
+.dashboard-layout {
+  height: 100vh;
+  display: flex;
+  overflow: hidden;
+}
+
+.dashboard-content {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+.dashboard-main {
+  flex: 1;
+  overflow-y: auto;
+  min-height: 0;
+}
+
+/* Modal and Dialog scrolling fixes */
+[data-radix-dialog-content],
+[data-radix-sheet-content],
+[data-radix-drawer-content] {
+  max-height: 90vh !important;
+  overflow-y: auto !important;
+}
+
+/* Dialog content scrolling */
+.fixed.left-\[50\%\].top-\[50\%\].z-50 {
+  max-height: 90vh !important;
+  overflow-y: auto !important;
+}
+
+/* Sheet content scrolling */
+.fixed.inset-y-0.right-0.h-full {
+  overflow-y: auto !important;
+}
+
+/* Drawer content scrolling */
+.fixed.inset-x-0.bottom-0.z-50 {
+  max-height: 80vh !important;
+  overflow-y: auto !important;
+}
+
+/* Chatbot widget scrolling */
+.fixed.z-50.bottom-24.right-6 {
+  max-height: 80vh !important;
+}
+
+/* Workspace sub-sidebar scrolling */
+.fixed.inset-y-0.left-64.z-40 {
+  overflow-y: auto !important;
+}
+
+/* Source form scrolling areas */
+.max-h-64.overflow-y-auto,
+.max-h-96.overflow-y-auto {
+  max-height: 300px !important;
+  overflow-y: auto !important;
+}
+
+/* Table scrolling */
+.relative.w-full.overflow-auto {
+  max-height: 70vh !important;
+  overflow-y: auto !important;
+}
+
+/* Command component scrolling */
+.max-h-\[300px\].overflow-y-auto {
+  max-height: 300px !important;
+  overflow-y: auto !important;
+}
+
+/* Context menu scrolling */
+.z-50.max-h-\[--radix-context-menu-content-available-height\] {
+  max-height: 60vh !important;
+  overflow-y: auto !important;
+}
+
+/* Toast container */
+.fixed.top-0.z-\[100\].flex.max-h-screen {
+  max-height: 100vh !important;
+  overflow: hidden !important;
+}
+
+/* Sidebar content scrolling */
+.flex.min-h-0.flex-1.flex-col.gap-2.overflow-auto {
+  overflow-y: auto !important;
+  max-height: calc(100vh - 200px) !important;
+}
+
 /* Force white background for all input fields */
 input,
 textarea,

--- a/src/layouts/dashboard-layout.jsx
+++ b/src/layouts/dashboard-layout.jsx
@@ -30,10 +30,10 @@ export default function DashboardLayout({ children }) {
   }, []);
 
   return (
-    <div className="h-screen flex overflow-hidden bg-white">
+    <div className="dashboard-layout bg-white">
       <Sidebar sidebarOpen={sidebarOpen} setSidebarOpen={setSidebarOpen} />
 
-      <div className="flex-1 flex flex-col overflow-hidden">
+      <div className="dashboard-content">
         {isMobile && (
           <div className="bg-white border-b border-gray-200 p-4 lg:hidden">
             <button
@@ -134,7 +134,7 @@ export default function DashboardLayout({ children }) {
         </div>
 
         {/* Main Content */}
-        <main className="overflow-y-auto p-6 bg-gray-50 flex flex-col items-start justify-start min-h-0">
+        <main className="dashboard-main p-6 bg-gray-50">
           {children}
         </main>
       </div>

--- a/src/pages/dashboard.jsx
+++ b/src/pages/dashboard.jsx
@@ -53,7 +53,7 @@ export default function Dashboard() {
 
   if (authLoading || statsLoading) {
     return (
-      <div className="min-h-screen bg-gray-50 flex items-center justify-center">
+      <div className="h-screen bg-gray-50 flex items-center justify-center">
         <div className="text-center">
           <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-blue-600 mx-auto mb-4"></div>
           <p className="text-gray-600">Loading dashboard...</p>
@@ -70,7 +70,7 @@ export default function Dashboard() {
   };
 
   return (
-    <div className="min-h-screen bg-gray-50">
+    <div className="h-screen bg-gray-50 overflow-hidden">
       {/* Header */}
       <header className="bg-white shadow-sm border-b">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
@@ -100,7 +100,7 @@ export default function Dashboard() {
       </header>
 
       {/* Main Content */}
-      <main className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+      <main className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8 overflow-y-auto h-[calc(100vh-4rem)]">
         {/* Welcome Section */}
         <div className="mb-8">
           <h2 className="text-2xl font-bold text-gray-900 mb-2">Dashboard Overview</h2>

--- a/src/pages/login.jsx
+++ b/src/pages/login.jsx
@@ -20,7 +20,7 @@ export default function Login() {
   };
 
   return (
-    <div className="min-h-screen relative overflow-hidden flex items-center justify-center p-4">
+    <div className="h-screen relative overflow-hidden flex items-center justify-center p-4">
       {/* Animated Background */}
       <div className="absolute inset-0 bg-gradient-to-br from-blue-50 via-cyan-50 to-indigo-100">
         {/* Floating background elements */}


### PR DESCRIPTION
I was able to delete the extra spacing at the bottom of the page, and restrict the extended scrolling. But trying to understand if that's all we need or work on any sub-pages/windows to fix the scrolling for any dropdowns or as the content grows.